### PR TITLE
Add ordered list support

### DIFF
--- a/src/nodeToHatena.js
+++ b/src/nodeToHatena.js
@@ -43,7 +43,7 @@ const converter = {
 
   listItem (node, opts) {
     const level = opts.level || 0;
-    return '----------'.slice(0, level) + ' ' + node.children.map(n => {
+    return '-'.repeat(level) + ' ' + node.children.map(n => {
       const h = nodeToHatena(n, { ...opts, level });
       return n.type === 'list' ? `\n${h}` : h;
     }).join('');

--- a/src/nodeToHatena.js
+++ b/src/nodeToHatena.js
@@ -37,8 +37,8 @@ const converter = {
   },
 
   list (node, opts) {
-    const level = opts.level || 0;
-    return node.children.map(n => nodeToHatena(n, { ...opts, level: level + 1 })).join('\n');
+    const level = (opts.level || 0) + 1;
+    return node.children.map(n => nodeToHatena(n, { ...opts, level })).join('\n');
   },
 
   listItem (node, opts) {

--- a/src/nodeToHatena.js
+++ b/src/nodeToHatena.js
@@ -38,12 +38,15 @@ const converter = {
 
   list (node, opts) {
     const level = (opts.level || 0) + 1;
-    return node.children.map(n => nodeToHatena(n, { ...opts, level })).join('\n');
+    const ordered = node.ordered || false;
+    return node.children.map(n => nodeToHatena(n, { ...opts, level, ordered })).join('\n');
   },
 
   listItem (node, opts) {
     const level = opts.level || 0;
-    return '-'.repeat(level) + ' ' + node.children.map(n => {
+    const ordered = opts.ordered || false;
+    const symbol = ordered ? '+' : '-';
+    return symbol.repeat(level) + ' ' + node.children.map(n => {
       const h = nodeToHatena(n, { ...opts, level });
       return n.type === 'list' ? `\n${h}` : h;
     }).join('');

--- a/test/input.md
+++ b/test/input.md
@@ -175,5 +175,9 @@ yay [^alpha] yay
 - foo
 - bar
   - baz
+
+1. foo
+1. bar
+  1. baz
 ## qux
 quux

--- a/test/input.md
+++ b/test/input.md
@@ -174,10 +174,10 @@ yay [^alpha] yay
 
 - foo
 - bar
-  - baz
+    - baz
 
 1. foo
 1. bar
-  1. baz
+    1. baz
 ## qux
 quux

--- a/test/list.js
+++ b/test/list.js
@@ -24,7 +24,7 @@ test('nodeToHatena(list)', t => {
 });
 
 test('md2hatena(list)', async t => {
-  t.is(await md2hatena('- foo\n- bar\n  - baz'), '- foo\n- bar\n-- baz');
+  t.is(await md2hatena('- foo\n- bar\n    - baz'), '- foo\n- bar\n-- baz');
 });
 
 test('md2hatena(ordered list)', async t => {
@@ -51,5 +51,5 @@ test('md2hatena(ordered list)', async t => {
 });
 
 test('md2hatena(ordered list)', async t => {
-  t.is(await md2hatena('1. foo\n1. bar\n  1. baz'), '+ foo\n+ bar\n++ baz');
+  t.is(await md2hatena('1. foo\n1. bar\n    1. baz'), '+ foo\n+ bar\n++ baz');
 });

--- a/test/list.js
+++ b/test/list.js
@@ -26,3 +26,30 @@ test('nodeToHatena(list)', t => {
 test('md2hatena(list)', async t => {
   t.is(await md2hatena('- foo\n- bar\n  - baz'), '- foo\n- bar\n-- baz');
 });
+
+test('md2hatena(ordered list)', async t => {
+  const text = t => ({ type: 'text', value: t });
+  const p = t => ({ type: 'paragraph', children: [text(t)] });
+  const list = {
+    type: 'list',
+    ordered: true,
+    children: [
+      { type: 'listItem', children: [p('foo')] },
+      { type: 'listItem', children: [
+        text('bar'),
+        {
+          type: 'list',
+          ordered: true,
+          children: [
+            { type: 'listItem', children: [p('baz')] },
+          ],
+        },
+      ] },
+    ],
+  };
+  t.is(nodeToHatena(list), '+ foo\n+ bar\n++ baz');
+});
+
+test('md2hatena(ordered list)', async t => {
+  t.is(await md2hatena('1. foo\n1. bar\n  1. baz'), '+ foo\n+ bar\n++ baz');
+});

--- a/test/output.hatena
+++ b/test/output.hatena
@@ -172,6 +172,10 @@ yay ((bravo)) yay
 - bar
 -- baz
 
++ foo
++ bar
+++ baz
+
 ** qux
 
 quux


### PR DESCRIPTION
Hatena Syntax has ordered list ( `+` ) syntax. I added ordered list support.

In addition, I fixed tests for unordered list because it seems that list syntax with 4 spaces is expected.
